### PR TITLE
Feat: AI를 이용한 유저의 상품 설명 추천 기능 #31

### DIFF
--- a/src/main/java/com/sparta/gaeppa/ai/controller/AIController.java
+++ b/src/main/java/com/sparta/gaeppa/ai/controller/AIController.java
@@ -1,0 +1,42 @@
+package com.sparta.gaeppa.ai.controller;
+
+import static com.sparta.gaeppa.global.util.ApiResponseUtil.success;
+
+import com.sparta.gaeppa.ai.dto.AssistProductDescriptionRequestDto;
+import com.sparta.gaeppa.ai.dto.AssistProductDescriptionResponseDto;
+import com.sparta.gaeppa.ai.dto.SystemPromptRequestDto;
+import com.sparta.gaeppa.ai.dto.SystemPromptResponseDto;
+import com.sparta.gaeppa.ai.service.AIService;
+import com.sparta.gaeppa.global.util.ApiResponseUtil.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/ai")
+@RequiredArgsConstructor
+public class AIController {
+
+    private final AIService aiService;
+
+    @PostMapping("/assist/product-description")
+    public ResponseEntity<ApiResult<AssistProductDescriptionResponseDto>> getProductDescription(
+            @RequestBody AssistProductDescriptionRequestDto requestDto) {
+
+        AssistProductDescriptionResponseDto responseDto = aiService.getProductDescription(requestDto);
+
+        return new ResponseEntity<>(success(responseDto), HttpStatus.OK);
+    }
+
+    @PostMapping("/system-prompt")
+    public ResponseEntity<ApiResult<SystemPromptResponseDto>> createSystemPrompt(
+            @RequestBody SystemPromptRequestDto requestDto) {
+        SystemPromptResponseDto responseDto = aiService.createSystemPrompt(requestDto);
+
+        return new ResponseEntity<>(success(responseDto), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/controller/AIController.java
+++ b/src/main/java/com/sparta/gaeppa/ai/controller/AIController.java
@@ -11,6 +11,7 @@ import com.sparta.gaeppa.global.util.ApiResponseUtil.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,7 +36,16 @@ public class AIController {
     @PostMapping("/system-prompt")
     public ResponseEntity<ApiResult<SystemPromptResponseDto>> createSystemPrompt(
             @RequestBody SystemPromptRequestDto requestDto) {
+        
         SystemPromptResponseDto responseDto = aiService.createSystemPrompt(requestDto);
+
+        return new ResponseEntity<>(success(responseDto), HttpStatus.OK);
+    }
+
+    @GetMapping("/system-prompt")
+    public ResponseEntity<ApiResult<SystemPromptResponseDto>> getSystemPrompt() {
+
+        SystemPromptResponseDto responseDto = aiService.getSystemPrompt();
 
         return new ResponseEntity<>(success(responseDto), HttpStatus.OK);
     }

--- a/src/main/java/com/sparta/gaeppa/ai/dto/AssistProductDescriptionRequestDto.java
+++ b/src/main/java/com/sparta/gaeppa/ai/dto/AssistProductDescriptionRequestDto.java
@@ -1,0 +1,18 @@
+package com.sparta.gaeppa.ai.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AssistProductDescriptionRequestDto {
+    @NotBlank
+    private String productName;
+    private String productDescription;
+}

--- a/src/main/java/com/sparta/gaeppa/ai/dto/AssistProductDescriptionResponseDto.java
+++ b/src/main/java/com/sparta/gaeppa/ai/dto/AssistProductDescriptionResponseDto.java
@@ -1,0 +1,12 @@
+package com.sparta.gaeppa.ai.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class AssistProductDescriptionResponseDto {
+    private String productDescriptionRecommendation;
+}

--- a/src/main/java/com/sparta/gaeppa/ai/dto/Gemini1_5ResponseDto.java
+++ b/src/main/java/com/sparta/gaeppa/ai/dto/Gemini1_5ResponseDto.java
@@ -1,0 +1,55 @@
+package com.sparta.gaeppa.ai.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Gemini1_5ResponseDto {
+    private List<Candidate> candidates;
+    private PromptFeedback promptFeedback;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Candidate {
+        private Content content;
+        private String finishReason;
+        private int index;
+        private List<SafetyRating> safetyRatings;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Content {
+        private List<Part> parts;
+        private String role;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Part {
+        private String text;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class SafetyRating {
+        private String category;
+        private String probability;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class PromptFeedback {
+        private List<SafetyRating> safetyRatings;
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/dto/Gemini1_5TextRequestDto.java
+++ b/src/main/java/com/sparta/gaeppa/ai/dto/Gemini1_5TextRequestDto.java
@@ -1,0 +1,49 @@
+package com.sparta.gaeppa.ai.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Gemini1_5TextRequestDto {
+    private List<Content> contents;
+
+    // text 값을 받아서 초기화하는 생성자
+    @Builder
+    public Gemini1_5TextRequestDto(String text) {
+        Content content = new Content(text);
+        this.contents = new ArrayList<>();
+        this.contents.add(content);
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Content {
+        private List<Part> parts;
+
+        public Content(String text) {
+            Part part = new Part(text);
+            this.parts = new ArrayList<>();
+            this.parts.add(part);
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Part {
+        private String text;
+
+        public Part(String text) {
+            this.text = text;
+        }
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/dto/SystemPromptRequestDto.java
+++ b/src/main/java/com/sparta/gaeppa/ai/dto/SystemPromptRequestDto.java
@@ -1,0 +1,18 @@
+package com.sparta.gaeppa.ai.dto;
+
+import com.sparta.gaeppa.ai.entity.AIPrompt;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SystemPromptRequestDto {
+    private String prompt;
+
+    public AIPrompt toEntity() {
+        return AIPrompt.builder()
+                .prompt(prompt)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/dto/SystemPromptResponseDto.java
+++ b/src/main/java/com/sparta/gaeppa/ai/dto/SystemPromptResponseDto.java
@@ -1,0 +1,20 @@
+package com.sparta.gaeppa.ai.dto;
+
+import com.sparta.gaeppa.ai.entity.AIPrompt;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class SystemPromptResponseDto {
+
+    private String prompt;
+
+    public static SystemPromptResponseDto from(AIPrompt aiPrompt) {
+        return SystemPromptResponseDto.builder()
+                .prompt(aiPrompt.getPrompt())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/entity/AIInteractionLog.java
+++ b/src/main/java/com/sparta/gaeppa/ai/entity/AIInteractionLog.java
@@ -1,0 +1,49 @@
+package com.sparta.gaeppa.ai.entity;
+
+import com.sparta.gaeppa.global.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_ai_interaction_logs")
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class AIInteractionLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "ai_interaction_log_id")
+    private UUID id;
+
+    @Column(name = "user_prompt", nullable = false, updatable = false, columnDefinition = "TEXT")
+    private String userPrompt;
+
+    @Column(name = "ai_response", nullable = false, updatable = false, columnDefinition = "TEXT")
+    private String aiResponse;
+
+    @Column(name = "ai_model_name", nullable = false)
+    private String aiModelName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ai_prompt_id")
+    private AIPrompt aiPrompt;
+
+    @Builder
+    private AIInteractionLog(String userPrompt, String aiResponse, String aiModelName, AIPrompt aiPrompt) {
+        this.userPrompt = userPrompt;
+        this.aiResponse = aiResponse;
+        this.aiModelName = aiModelName;
+        this.aiPrompt = aiPrompt;
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/entity/AIPrompt.java
+++ b/src/main/java/com/sparta/gaeppa/ai/entity/AIPrompt.java
@@ -1,0 +1,33 @@
+package com.sparta.gaeppa.ai.entity;
+
+import com.sparta.gaeppa.global.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_ai_prompts")
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class AIPrompt extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "ai_prompt_id")
+    private UUID id;
+
+    @Column(name = "prompt", nullable = false, updatable = false, columnDefinition = "TEXT")
+    private String prompt;
+
+    @Builder
+    private AIPrompt(String prompt) {
+        this.prompt = prompt;
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/model/AIModelFactory.java
+++ b/src/main/java/com/sparta/gaeppa/ai/model/AIModelFactory.java
@@ -1,0 +1,19 @@
+package com.sparta.gaeppa.ai.model;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AIModelFactory {
+
+    private final List<IAIModel> models;
+
+    public IAIModel getModel(String modelName) {
+        return models.stream()
+                .filter(model -> model.getName().equals(modelName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Model not found"));
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/model/Gemini1_5Model.java
+++ b/src/main/java/com/sparta/gaeppa/ai/model/Gemini1_5Model.java
@@ -1,0 +1,49 @@
+package com.sparta.gaeppa.ai.model;
+
+import com.sparta.gaeppa.ai.dto.Gemini1_5ResponseDto;
+import com.sparta.gaeppa.ai.dto.Gemini1_5TextRequestDto;
+import java.net.URI;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class Gemini1_5Model implements IAIModel {
+
+    public static final String MODEL_NAME = "Gemini1.5";
+
+    private static final String URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=";
+
+    private final RestTemplate restTemplate;
+
+    @Value("${google.ai.key}")
+    private String apiKey;
+
+    @Override
+    public String getName() {
+        return MODEL_NAME;
+    }
+
+    @Override
+    public String processTextRequest(String requestText) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        RequestEntity<Gemini1_5TextRequestDto> requestEntity = new RequestEntity<Gemini1_5TextRequestDto>(
+                Gemini1_5TextRequestDto.builder().text(requestText).build(), headers, HttpMethod.POST,
+                URI.create(URL + apiKey));
+
+        return Objects.requireNonNull(restTemplate.exchange(requestEntity, Gemini1_5ResponseDto.class).getBody())
+                .getCandidates().getFirst()
+                .getContent().getParts().getFirst().getText();
+
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/ai/model/IAIModel.java
+++ b/src/main/java/com/sparta/gaeppa/ai/model/IAIModel.java
@@ -1,0 +1,7 @@
+package com.sparta.gaeppa.ai.model;
+
+public interface IAIModel {
+    String getName();
+
+    String processTextRequest(String requestText);
+}

--- a/src/main/java/com/sparta/gaeppa/ai/repository/AIInteractionLogRepository.java
+++ b/src/main/java/com/sparta/gaeppa/ai/repository/AIInteractionLogRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.gaeppa.ai.repository;
+
+import com.sparta.gaeppa.ai.entity.AIInteractionLog;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AIInteractionLogRepository extends JpaRepository<AIInteractionLog, UUID> {
+}

--- a/src/main/java/com/sparta/gaeppa/ai/repository/AIPromptRepository.java
+++ b/src/main/java/com/sparta/gaeppa/ai/repository/AIPromptRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.gaeppa.ai.repository;
+
+import com.sparta.gaeppa.ai.entity.AIPrompt;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AIPromptRepository extends JpaRepository<AIPrompt, UUID> {
+    Optional<AIPrompt> findFirstByOrderByCreatedAtDesc();
+}

--- a/src/main/java/com/sparta/gaeppa/ai/service/AIService.java
+++ b/src/main/java/com/sparta/gaeppa/ai/service/AIService.java
@@ -81,4 +81,11 @@ public class AIService {
 
         return SystemPromptResponseDto.from(aiPrompt);
     }
+
+    public SystemPromptResponseDto getSystemPrompt() {
+        AIPrompt aiPrompt = aiPromptRepository.findFirstByOrderByCreatedAtDesc().orElseThrow(() -> new AIException(
+                ExceptionStatus.AI_PROMPT_NOT_FOUND));
+
+        return SystemPromptResponseDto.from(aiPrompt);
+    }
 }

--- a/src/main/java/com/sparta/gaeppa/ai/service/AIService.java
+++ b/src/main/java/com/sparta/gaeppa/ai/service/AIService.java
@@ -1,0 +1,84 @@
+package com.sparta.gaeppa.ai.service;
+
+import com.sparta.gaeppa.ai.dto.AssistProductDescriptionRequestDto;
+import com.sparta.gaeppa.ai.dto.AssistProductDescriptionResponseDto;
+import com.sparta.gaeppa.ai.dto.SystemPromptRequestDto;
+import com.sparta.gaeppa.ai.dto.SystemPromptResponseDto;
+import com.sparta.gaeppa.ai.entity.AIInteractionLog;
+import com.sparta.gaeppa.ai.entity.AIPrompt;
+import com.sparta.gaeppa.ai.model.AIModelFactory;
+import com.sparta.gaeppa.ai.repository.AIInteractionLogRepository;
+import com.sparta.gaeppa.ai.repository.AIPromptRepository;
+import com.sparta.gaeppa.global.exception.AIException;
+import com.sparta.gaeppa.global.exception.ExceptionStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AIService {
+
+    private final AIModelFactory aiModelFactory;
+    private final AIInteractionLogRepository aiInteractionLogRepository;
+    private final AIPromptRepository aiPromptRepository;
+
+    public AssistProductDescriptionResponseDto getProductDescription(AssistProductDescriptionRequestDto requestDto) {
+
+//        String prompt = """
+//                    음식 이름과 간단한 설명을 기반으로, 고객이 메뉴를 선택하도록 유도하는 매력적인 음식 설명을 작성해주세요.
+//                    설명은 50자 이내로 작성하되, 자극적이고 입맛을 돋우는 문구를 사용하여 손님들의 관심을 끌도록 합니다.
+//
+//                    **주요 포인트:**
+//                    - 음식을 한 번 먹으면 계속 먹고 싶어지는 유혹적인 문구
+//                    - 손님들이 이 음식을 선택하지 않을 수 없도록 만드는 설득력 있는 설명
+//                    - 50자 이내로 간결하면서도 강렬하게 어필
+//
+//                    **예시 1:**
+//                    입력:
+//                    이름: 불고기
+//                    설명: 손님들이 불고기를 선택하도록 유도하는 설명을 작성해주세요.
+//
+//                    출력:
+//                    우리집 불고기는 풍미 가득한 양념과 부드러운 고기, 그 맛이 한번 먹으면 멈출 수 없어요.
+//
+//                    **예시 2:**
+//                    입력:
+//                    이름: 치킨
+//                    설명: 맛있는 우리집 치킨
+//
+//                    출력:
+//                    바삭하고 육즙 가득한 우리 치킨, 한 입 먹으면 계속 손이 가는 맛!
+//
+//                    이와 같은 형식으로 유혹적인 음식 설명을 만들어주세요.
+
+//                """;
+
+        String AIModelName = "Gemini1.5";
+
+        AIPrompt prompt = aiPromptRepository.findFirstByOrderByCreatedAtDesc().orElseThrow(() -> new AIException(
+                ExceptionStatus.AI_PROMPT_NOT_FOUND));
+
+        String SystemPrompt = prompt.getPrompt();
+
+        String userPrompt = "이름: " + requestDto.getProductName() + "\n" + "설명: " + requestDto.getProductDescription();
+
+        String aiResponse = aiModelFactory.getModel(AIModelName).processTextRequest(SystemPrompt + userPrompt);
+
+        aiInteractionLogRepository.save(AIInteractionLog.builder()
+                .aiModelName(AIModelName)
+                .aiPrompt(prompt)
+                .userPrompt(userPrompt)
+                .aiResponse(aiResponse)
+                .build());
+
+        return AssistProductDescriptionResponseDto.builder()
+                .productDescriptionRecommendation(aiResponse)
+                .build();
+    }
+
+    public SystemPromptResponseDto createSystemPrompt(SystemPromptRequestDto requestDto) {
+        AIPrompt aiPrompt = aiPromptRepository.save(requestDto.toEntity());
+
+        return SystemPromptResponseDto.from(aiPrompt);
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/sparta/gaeppa/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.sparta.gaeppa.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/global/exception/AIException.java
+++ b/src/main/java/com/sparta/gaeppa/global/exception/AIException.java
@@ -1,0 +1,7 @@
+package com.sparta.gaeppa.global.exception;
+
+public class AIException extends DefaultException {
+    public AIException(ExceptionStatus exceptionStatus) {
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/com/sparta/gaeppa/global/exception/ExceptionStatus.java
+++ b/src/main/java/com/sparta/gaeppa/global/exception/ExceptionStatus.java
@@ -33,6 +33,9 @@ public enum ExceptionStatus {
     // ROLE
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "r001", "권한이 없습니다."), //Common
 
+    // AI
+    AI_PROMPT_NOT_FOUND(HttpStatus.NOT_FOUND, "a001", "AI 프롬프트가 존재하지 않습니다."),
+
     //Common
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "s001", "서버 에러입니다.");
 

--- a/src/main/java/com/sparta/gaeppa/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/gaeppa/global/exception/GlobalExceptionHandler.java
@@ -30,4 +30,17 @@ public class GlobalExceptionHandler {
         log.error("RepositoryException: {}", e.getMessage());
         return new ResponseEntity<>(error(e.getMessage()), new HttpHeaders(), e.getStatus());
     }
+
+    @ExceptionHandler(AIException.class)
+    public ResponseEntity<ApiResult<ApiError>> handleAIException(AIException e) {
+        log.error("AIException: {}", e.getMessage());
+        return new ResponseEntity<>(error(e.getMessage()), new HttpHeaders(), e.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResult<ApiError>> handleException(Exception e) {
+        log.error("Exception: {}", e.getMessage());
+        return new ResponseEntity<>(error(e.getMessage()), new HttpHeaders(),
+                ExceptionStatus.INTERNAL_SERVER_ERROR.getStatus());
+    }
 }

--- a/src/main/java/com/sparta/gaeppa/product/service/ProductCategoryService.java
+++ b/src/main/java/com/sparta/gaeppa/product/service/ProductCategoryService.java
@@ -29,9 +29,7 @@ public class ProductCategoryService {
 
         ProductCategory savedProductCategory = productCategoryRepository.save(requestDto.toEntity());
 
-        ProductCategory productCategory = productCategoryRepository.save(savedProductCategory);
-
-        return ProductCategoryResponseDto.from(productCategory);
+        return ProductCategoryResponseDto.from(savedProductCategory);
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,7 @@ spring:
 server:
   servlet:
     context-path: /api
+
+google:
+  ai:
+    key: ${GOOGLE_AI_API_KEY}


### PR DESCRIPTION
## 기능 설명
- AI 프롬포트를 등록 및 조회
- 유저가 입력한 상품 이름과 설명을 통하여 추천 상품 설명 문구 제공
  - 유저는 설명을 비워둘 수 있음
  - 유저는 자신이 작성한 설명을 입력하여 보충받을 수 있음
  - 유저는 원하는 상품설명의 방향성을 제시할 수 있음
- AI모델과 주고받은 내용은 DB에 기록

## 작업 내용
- AI Prompt 와 대화 로그를 저장하는 Entity 및 레포지토리 생성
- AI Contorller, service 개발
- Gemini1.5 를 이용하는 AIModel 클래스 개발
- AI 모델을 변경 및 되돌리는 상황에 유연하게 대처할 수 있도록 전략 패턴 사용

## 수정 사항

## 추가 작업 예정
---
## API 문서
https://documenter.getpostman.com/view/35982422/2sAY55ZxoG#a144ba3f-a4ae-4d66-aedf-153d2e43cd7c
