### PR TITLE
관리자 권한의 멤버와 스토어 전체 리스트 조회, 권한 수정, 스토어 영구 삭제 등 추가, MemberService DI 실패 에러 수정

### DIFF
--- a/src/main/java/com/sparta/gaeppa/global/util/MemberDataGenerator.java
+++ b/src/main/java/com/sparta/gaeppa/global/util/MemberDataGenerator.java
@@ -1,0 +1,2 @@
+package com.sparta.gaeppa.global.util;public class MemberDataGenerator {
+}

--- a/src/main/java/com/sparta/gaeppa/global/util/MemberDataGenerator.java
+++ b/src/main/java/com/sparta/gaeppa/global/util/MemberDataGenerator.java
@@ -1,2 +1,22 @@
-package com.sparta.gaeppa.global.util;public class MemberDataGenerator {
+package com.sparta.gaeppa.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("dummy")
+@Order(1) // 다른 순서 지정
+@RequiredArgsConstructor
+public class MemberDataGenerator implements ApplicationRunner {
+
+    private final MemberDataUtil memberDataUtil;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        memberDataUtil.generateMemberData();
+    }
 }

--- a/src/main/java/com/sparta/gaeppa/global/util/MemberDataUtil.java
+++ b/src/main/java/com/sparta/gaeppa/global/util/MemberDataUtil.java
@@ -1,2 +1,121 @@
-package com.sparta.gaeppa.global.util;public class MemberDataUtil {
+package com.sparta.gaeppa.global.util;
+
+import com.sparta.gaeppa.members.entity.LoginType;
+import com.sparta.gaeppa.members.entity.Member;
+import com.sparta.gaeppa.members.entity.MemberRole;
+import com.sparta.gaeppa.members.repository.MemberRepository;
+import com.sparta.gaeppa.profile.entity.Profile;
+import com.sparta.gaeppa.profile.repository.ProfileRepository;
+import com.sparta.gaeppa.store.dto.StoreCreateRequestDto;
+import com.sparta.gaeppa.store.entity.StoreCategory;
+import com.sparta.gaeppa.store.service.StoreCategoryService;
+import com.sparta.gaeppa.store.service.StoreService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberDataUtil {
+
+    private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final StoreService storeService;
+    private final StoreCategoryService storeCategoryService;
+
+    public void generateMemberData() {
+        // 고객 회원 생성
+        createCustomerMember("customer1@pushop.com", "roQkfmsalswhr!", "customer1");
+        createCustomerMember("customer2@pushop.com", "roQkfmsalswhr!", "customer2");
+        createCustomerMember("customer3@pushop.com", "roQkfmsalswhr!", "customer3");
+
+        // 스토어주인 회원 생성
+        Member owner1 = createOwnerMember("owner1@pushop.com", "roQkfmsalswhr!", "owner1");
+        Member owner2 = createOwnerMember("owner2@pushop.com", "roQkfmsalswhr!", "owner2");
+        Member owner3 = createOwnerMember("owner3@pushop.com", "roQkfmsalswhr!", "owner3");
+
+        // OWNER 회원들에게 스토어 생성
+        createStoreForOwner(owner1, "한식스토어1", "한식");
+        createStoreForOwner(owner2, "중식스토어2", "중식");
+        createStoreForOwner(owner3, "양식스토어3", "양식");
+
+        // 매니저 회원 생성
+        createManagerMember("manager1@pushop.com", "roQkfmsalswhr!", "manager1");
+        createManagerMember("manager2@pushop.com", "roQkfmsalswhr!", "manager2");
+        createManagerMember("manager3@pushop.com", "roQkfmsalswhr!", "manager3");
+
+        // 마스터 회원 생성
+        createMasterMember("master1@pushop.com", "roQkfmsalswhr!", "master1");
+        createMasterMember("master2@pushop.com", "roQkfmsalswhr!", "master2");
+        createMasterMember("master3@pushop.com", "roQkfmsalswhr!", "master3");
+    }
+
+    private void createCustomerMember(String email, String password, String username) {
+        Member customerMember = buildMember(email, password, username, MemberRole.CUSTOMER);
+        saveMemberAndProfile(customerMember);
+    }
+
+    private Member createOwnerMember(String email, String password, String username) {
+        Member ownerMember = buildMember(email, password, username, MemberRole.OWNER);
+        return saveMemberAndProfile(ownerMember);
+    }
+
+    private Member buildMember(String email, String password, String username, MemberRole role) {
+        String providerUserId = generateProviderUserId();
+        String emailToken = UUID.randomUUID().toString();
+
+        return Member.builder()
+                .email(email)
+                .username(username)
+                .password(passwordEncoder.encode(password))
+                .emailToken(emailToken)
+                .providerUserId(providerUserId)
+                .loginType(LoginType.GENERAL)
+                .role(role)
+                .isCertifyByMail(true)
+                .build();
+    }
+
+    private void createManagerMember(String email, String password, String username) {
+        Member managerMember = buildMember(email, password, username, MemberRole.MANAGER);
+        saveMemberAndProfile(managerMember);
+    }
+
+    private void createMasterMember(String email, String password, String username) {
+        Member masterMember = buildMember(email, password, username, MemberRole.MASTER);
+        saveMemberAndProfile(masterMember);
+    }
+
+
+    private Member saveMemberAndProfile(Member member) {
+        Member savedMember = memberRepository.save(member);
+        Profile profile = Profile.createMemberProfile(savedMember);
+        profileRepository.save(profile);
+        return savedMember;
+    }
+
+    private String generateProviderUserId() {
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        return "GENERAL-" + uuid.substring(0, 12);
+    }
+
+    private void createStoreForOwner(Member owner, String storeName, String categoryName) {
+        // 카테고리 생성
+        StoreCategory storeCategory = storeCategoryService.createIfNotExists(categoryName);
+
+        // 스토어 생성 요청 DTO
+        StoreCreateRequestDto storeRequestDto = StoreCreateRequestDto.builder()
+                .storeName(storeName)
+                .storeCategoryName(storeCategory.getCategoryName())
+                .storeAddress("서울특별시 강남구 테헤란로 123")
+                .storeTelephone("010-1234-5678")
+                .storeIntroduce("이곳은 최고의 장소입니다.")
+                .businessTime("09:00 - 22:00")
+                .build();
+
+        // 스토어 생성 (Owner ID 사용)
+        storeService.createOwnerStore(storeRequestDto, owner.getMemberId());
+    }
 }

--- a/src/main/java/com/sparta/gaeppa/global/util/MemberDataUtil.java
+++ b/src/main/java/com/sparta/gaeppa/global/util/MemberDataUtil.java
@@ -1,0 +1,2 @@
+package com.sparta.gaeppa.global.util;public class MemberDataUtil {
+}

--- a/src/main/java/com/sparta/gaeppa/members/controller/AdminController.java
+++ b/src/main/java/com/sparta/gaeppa/members/controller/AdminController.java
@@ -3,10 +3,12 @@ package com.sparta.gaeppa.members.controller;
 import static com.sparta.gaeppa.global.util.ApiResponseUtil.success;
 
 import com.sparta.gaeppa.global.util.ApiResponseUtil.ApiResult;
-import com.sparta.gaeppa.members.dto.admin.MemberRoleRequestDto;
-import com.sparta.gaeppa.members.dto.join.JoinResponseDto;
+import com.sparta.gaeppa.members.dto.admin.MemberResponseDto;
+import com.sparta.gaeppa.members.entity.Member;
 import com.sparta.gaeppa.members.service.MemberService;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -22,18 +24,34 @@ public class AdminController {
     private final MemberService memberService;
 
     /**
+     * 회원의 MemberRole을 수정
      *
-     * @param request
-     * @return
-     * @throws Exception
+     * @param requestDto
+     * @return ResponseEntity<ApiResult<JoinResponseDto>>
      */
-    @PutMapping("/role")
-    public ResponseEntity<ApiResult<JoinResponseDto>> joinGeneralMember(@RequestBody @Valid MemberRoleRequestDto request)
-            throws Exception {
+    @PutMapping("/members/role/{memberID}")
+    public ResponseEntity<ApiResult<MemberResponseDto>> updateMemberRole(
+            @RequestBody @Valid MemberResponseDto requestDto, @PathVariable UUID memberID) {
 
-//        JoinResponseDto joinResponseDto = memberService.joinMemberByEmailAuthentication(request);
+        // 회원의 역할(Role) 업데이트
+        Member updatedMember = memberService.updateMemberRole(requestDto, memberID);
 
-//        return new ResponseEntity<>(success(joinResponseDto), HttpStatus.CREATED);
-        return null;
+        // DTO로 변환 후 반환
+        MemberResponseDto responseDto = MemberResponseDto.fromEntity(updatedMember);
+        return new ResponseEntity<>(success(responseDto), HttpStatus.OK);
+    }
+
+    @GetMapping("/members")
+    public ResponseEntity<ApiResult<List<MemberResponseDto>>> getMembersListByAdmin() {
+        // 모든 회원을 조회
+        List<Member> allMembers = memberService.findAllMembers();
+
+        // Member 리스트를 MemberResponseDto 리스트로 변환
+        List<MemberResponseDto> memberResponseDtos = allMembers.stream()
+                .map(MemberResponseDto::fromEntity) // 각 Member를 MemberResponseDto로 변환
+                .toList();
+
+        // 결과 반환
+        return new ResponseEntity<>(success(memberResponseDtos), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sparta/gaeppa/members/dto/admin/MemberResponseDto.java
+++ b/src/main/java/com/sparta/gaeppa/members/dto/admin/MemberResponseDto.java
@@ -1,2 +1,46 @@
-package com.sparta.gaeppa.members.dto.admin;public class MemberResponseDto {
+package com.sparta.gaeppa.members.dto.admin;
+
+import com.sparta.gaeppa.members.entity.LoginType;
+import com.sparta.gaeppa.members.entity.Member;
+import com.sparta.gaeppa.members.entity.MemberRole;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MemberResponseDto {
+
+    private UUID memberId;
+    private String email;
+    private String username;
+    private MemberRole role;
+    private LoginType loginType;
+    private String providerUserId;
+    private boolean isCertifyByMail;
+    private boolean isActivated;
+    private boolean isAccountNonLocked;
+    private LocalDateTime lastLoginAt;
+
+    // Entity -> DTO 변환 메서드
+    public static MemberResponseDto fromEntity(Member member) {
+        return MemberResponseDto.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .username(member.getUsername())
+                .role(member.getRole())
+                .loginType(member.getLoginType())
+                .providerUserId(member.getProviderUserId())
+                .isCertifyByMail(member.isCertifyByMail())
+                .isActivated(member.isActivated())
+                .isAccountNonLocked(member.isAccountNonLocked())
+                .lastLoginAt(member.getLastLoginAt())
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/gaeppa/members/dto/admin/MemberResponseDto.java
+++ b/src/main/java/com/sparta/gaeppa/members/dto/admin/MemberResponseDto.java
@@ -1,0 +1,2 @@
+package com.sparta.gaeppa.members.dto.admin;public class MemberResponseDto {
+}

--- a/src/main/java/com/sparta/gaeppa/members/dto/admin/MemberRoleRequestDto.java
+++ b/src/main/java/com/sparta/gaeppa/members/dto/admin/MemberRoleRequestDto.java
@@ -1,4 +1,0 @@
-package com.sparta.gaeppa.members.dto.admin;
-
-public class MemberRoleRequestDto {
-}

--- a/src/main/java/com/sparta/gaeppa/members/entity/Member.java
+++ b/src/main/java/com/sparta/gaeppa/members/entity/Member.java
@@ -48,7 +48,7 @@ public class Member extends BaseEntity {
     private LoginType loginType;
 
     @Column(name = "provider_user_id", unique = true, nullable = false)
-    private String providerUserId; // Provider + provider Id 형식
+    private String providerUserId; // Provider + "-" + provider Id 형식
 
     @Column(name = "email_token")
     private String emailToken;
@@ -101,6 +101,10 @@ public class Member extends BaseEntity {
 
     public void setLastLoginDate(LocalDateTime now) {
         this.lastLoginAt = now;
+    }
+
+    public void updateRole(MemberRole newRole) {
+        this.role = newRole;
     }
 
     // 일반 회원 생성 메서드

--- a/src/main/java/com/sparta/gaeppa/members/entity/MemberGender.java
+++ b/src/main/java/com/sparta/gaeppa/members/entity/MemberGender.java
@@ -1,5 +1,5 @@
 package com.sparta.gaeppa.members.entity;
 
 public enum MemberGender {
-    MALE, FEMALE, OTHER
+    MALE, FEMALE, OTHER, NON_PROVIDED
 }

--- a/src/main/java/com/sparta/gaeppa/members/service/MemberService.java
+++ b/src/main/java/com/sparta/gaeppa/members/service/MemberService.java
@@ -2,6 +2,7 @@ package com.sparta.gaeppa.members.service;
 
 import com.sparta.gaeppa.global.exception.ExceptionStatus;
 import com.sparta.gaeppa.global.exception.ServiceException;
+import com.sparta.gaeppa.members.dto.admin.MemberResponseDto;
 import com.sparta.gaeppa.members.dto.join.JoinGeneralMemberRequestDto;
 import com.sparta.gaeppa.members.dto.join.JoinMasterMemberRequestDto;
 import com.sparta.gaeppa.members.dto.join.JoinResponseDto;
@@ -237,6 +238,27 @@ public class MemberService {
         }
 
         return generalMembers.getFirst();
+    }
+
+    public List<Member> findAllMembers() {
+        return memberRepository.findAll();
+    }
+
+    /**
+     * 회원의 MemberRole을 업데이트
+     *
+     * @param requestDto 요청 DTO
+     * @return 업데이트된 Member 엔티티
+     */
+    public Member updateMemberRole(MemberResponseDto requestDto, UUID memberId) {
+        // 회원 조회
+        Member member = memberRepository.findById(requestDto.getMemberId())
+                .orElseThrow(() -> new ServiceException(ExceptionStatus.MEMBER_NOT_FOUND));
+
+        // 역할 업데이트
+        member.updateRole(requestDto.getRole());
+
+        return memberRepository.save(member);
     }
 
     // 사용자 정의 예외 클래스

--- a/src/main/java/com/sparta/gaeppa/profile/controller/ProfileController.java
+++ b/src/main/java/com/sparta/gaeppa/profile/controller/ProfileController.java
@@ -88,10 +88,10 @@ public class ProfileController {
      * @param storeId 스토어 ID
      * @return 즐겨찾기 상태와 메시지
      */
-    @PostMapping("/favorites")
+    @PostMapping("/favorites/{storeId}")
     public ResponseEntity<ApiResult<String>> toggleFavorite(
             @RequestParam UUID profileId,
-            @RequestParam UUID storeId) {
+            @PathVariable UUID storeId) {
         // 서비스 계층에 토글 로직 위임
         String message = profileService.toggleFavorite(profileId, storeId);
 

--- a/src/main/java/com/sparta/gaeppa/profile/entity/Profile.java
+++ b/src/main/java/com/sparta/gaeppa/profile/entity/Profile.java
@@ -64,9 +64,13 @@ public class Profile extends BaseEntity {
         this.memberGender = memberGender;
     }
 
-    // 최초 회원가입 시, 기본적으로 만들어주는 프로필. Profile 과 Member 는 강한 종속성을 띱니다.
+    /**
+     * 최초 회원가입 시, 기본적으로 만들어주는 프로필. Profile 과 Member 는 강한 종속성을 띱니다.
+     * Member 는 인증, 인가에 대한 책임
+     * Profile 은 회원 서비스에 대한 책임을 갖습니다.
+      */
     public static Profile createMemberProfile(Member member) {
-        return new Profile(member, "자기 소개를 수정해주세요. ", null, null, null);
+        return new Profile(member, "프로필이미지없음", null, "소개 없음", MemberGender.NON_PROVIDED);
     }
 
     // 프로필 이미지 설정 메서드

--- a/src/main/java/com/sparta/gaeppa/security/jwts/entity/Refresh.java
+++ b/src/main/java/com/sparta/gaeppa/security/jwts/entity/Refresh.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@Table(name = "refresh")
+@Table(name = "p_refresh")
 public class Refresh {
 
     @Id

--- a/src/main/java/com/sparta/gaeppa/store/controller/StoreAdminController.java
+++ b/src/main/java/com/sparta/gaeppa/store/controller/StoreAdminController.java
@@ -1,7 +1,19 @@
 package com.sparta.gaeppa.store.controller;
 
+import static com.sparta.gaeppa.global.util.ApiResponseUtil.success;
+
+import com.sparta.gaeppa.global.util.ApiResponseUtil.ApiResult;
+import com.sparta.gaeppa.store.entity.Store;
+import com.sparta.gaeppa.store.service.StoreService;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,8 +22,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Slf4j
 public class StoreAdminController {
-    // 1. 가게 전체를 조회하는 일 [ROLE : MANAGER, MASTER] -> StoreAdminController
-    // 2. 가게를 아예 삭제하는 일 [ROLE : MANAGER, MASTER] -> StoreAdminController
 
+    private final StoreService storeService;
+
+    // 1. 가게 전체를 조회하는 일 [ROLE : MANAGER, MASTER] -> StoreAdminController
+    @GetMapping
+    public ResponseEntity<ApiResult<List<Store>>> getAllStores() {
+        List<Store> stores = storeService.getAllStores();
+        return new ResponseEntity<>(success(stores), HttpStatus.OK);
+    }
+
+    // 2. 가게 삭제 API [ROLE : MANAGER, MASTER]
+    @DeleteMapping("/{storeId}")
+    public ResponseEntity<ApiResult<String>> deleteStore(@PathVariable UUID storeId) {
+        storeService.deleteStore(storeId);
+        return new ResponseEntity<>(success("Store가 정상 삭제 되었습니다."), HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/com/sparta/gaeppa/store/entity/Favorite.java
+++ b/src/main/java/com/sparta/gaeppa/store/entity/Favorite.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "favorite")
+@Table(name = "p_favorite")
 public class Favorite extends BaseEntity {
 
     @Id

--- a/src/main/java/com/sparta/gaeppa/store/entity/Store.java
+++ b/src/main/java/com/sparta/gaeppa/store/entity/Store.java
@@ -64,7 +64,8 @@ public class Store extends BaseEntity {
     private int reviewCount = 0;
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Favorite> favoritedBy = new ArrayList<>(); // 즐겨찾기된 기록
+    private List<Favorite> favoritedBy = new ArrayList<>();
+
 
     public Store(UUID storeId, Member member, StoreCategory category, String storeName, String storeAddress,
                  String storeTelephone, String storeIntroduce, String businessTime, boolean isVisible,

--- a/src/main/java/com/sparta/gaeppa/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/gaeppa/store/repository/StoreRepository.java
@@ -1,13 +1,14 @@
 package com.sparta.gaeppa.store.repository;
 
 import com.sparta.gaeppa.store.entity.Store;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StoreRepository extends JpaRepository<Store, UUID> {
-    Store findByMemberMemberId(UUID memberId);
+    Optional<Store> findByMemberMemberId(UUID memberId);
 
     Store findByStoreName(String storeName);
 }

--- a/src/main/java/com/sparta/gaeppa/store/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/gaeppa/store/service/StoreCategoryService.java
@@ -49,9 +49,7 @@ public class StoreCategoryService {
      */
     @Transactional
     public StoreCategory createIfNotExists(String storeCategoryName) {
-        if (storeCategoryRepository.findByCategoryName(storeCategoryName).isPresent()) {
-            throw new ServiceException(ExceptionStatus.CATEGORY_ALREADY_EXISTS);
-        }
-        return createStoreCategoryByName(storeCategoryName);
+        return storeCategoryRepository.findByCategoryName(storeCategoryName)
+                .orElseGet(() -> createStoreCategoryByName(storeCategoryName));
     }
 }

--- a/src/main/resources/application-build.yml
+++ b/src/main/resources/application-build.yml
@@ -1,5 +1,11 @@
 spring:
   jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        default_batch_fetch_size: 1000 #최적화 옵션
     hibernate:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
@@ -9,11 +15,6 @@ spring:
       #  update	변경된 스키마 적용 (운영 DB 에서 사용X)
       #  validate Entity 와 테이블이 정상 매핑 되었는지 확인
       #  none 기존테이블을 더 이상 건드리지 않음.
-    properties:
-      hibernate:
-        #        show_sql: true
-        format_sql: false
-        default_batch_fetch_size: 1000 #최적화 옵션
     open-in-view: true
 
   jackson:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     # develop : develop 환경에서 application run 을 실행
     # production : 실 사용자가 사용하는 환경에서 application run 을 실행
     # staging : 실 사용자는 없지만, 마지막 테스트 환경에서 application run 을 실행
-    active: none # <develop, production, staging, none> 옵션
+    active: none # <dummy, production, staging, none> 옵션
     include: build, services, security, storage
   datasource:
     #  ================= H2 =================


### PR DESCRIPTION
## 기능 설명
1. 회원 데이터 생성 기능
MemberDataGenerator 및 MemberDataUtil 구현:
개발 및 테스트 환경에서 더미 회원 데이터를 생성할 수 있도록 기능 추가.
다양한 회원 유형(고객, 스토어 소유자, 관리자 등)을 빌더 패턴으로 생성.
각 회원에게 프로필을 생성하고, 스토어 소유자에게는 기본 스토어를 할당.
2. 회원 관련 기능
Member 엔티티 수정:

providerUserId의 유니크 제약 조건 추가 및 값 생성 방식 통일.
updateRole 메서드 추가로 회원 권한(Role) 변경 가능.
MemberResponseDto 추가:

API 응답에서 사용될 DTO 추가.
fromEntity 메서드로 엔티티를 DTO로 변환.
MemberService 수정:

findAllMembers: 모든 회원을 조회하는 기능 추가.
updateMemberRole: 회원의 역할(Role)을 업데이트하는 기능 추가.
AdminController 수정:

회원 리스트 조회 API 추가.
회원 역할 업데이트 API 개선.
3. 스토어 관련 기능
Store 생성 및 관리 개선:

소유자와 연결된 스토어를 생성하는 기능(createOwnerStore) 추가.
스토어를 회원 ID(MemberId)로 조회하는 기능(getMyStoreByMemberId) 추가.
전체 스토어를 조회하거나 스토어를 삭제하는 관리 기능 추가.
Store 엔티티 수정:

Favorite 테이블 명칭 변경(p_favorite).
기존 연관 관계와 가독성을 개선.
StoreCategoryService 개선:

카테고리를 생성하기 전에 중복 확인 및 처리 방식 개선(createIfNotExists).
4. 프로필 관련 기능
프로필 기본 값 수정:
프로필 생성 시 초기 설정 값을 개선(예: 기본 자기소개 및 성별).
Profile.createMemberProfile 메서드 수정.
5. 기타 수정
Refresh, Favorite 등 테이블 명칭 변경(p_ 접두어 추가).
Spring JPA 최적화: default_batch_fetch_size 설정 추가.
YML 파일에서 Profile 값 추가(dummy 환경 추가).

## 작업 내용

## 수정 사항
코드 리팩토링:

엔티티 및 서비스 계층에서 중복된 코드를 제거하고 가독성 향상.
DTO와 Entity 간 변환 로직 추가로 응답 데이터 처리 일원화.
테이블 명칭 변경:

p_ 접두어로 테이블 명칭 표준화.
API 개선:

관리자(AdminController)가 회원 및 스토어를 효과적으로 관리할 수 있도록 API 엔드포인트 확장.
빌더 패턴 적용:

Member, StoreCreateRequestDto 등 빌더 패턴 적용으로 코드 가독성 및 유연성 개선.
## 추가 작업 예정
테스트 케이스 작성:

신규 API 및 데이터 생성 유틸에 대한 통합 테스트 및 단위 테스트 작성.