### PR TITLE
Fix : 리뷰 평점 계산 반올림 삭제, 리뷰 삭제 요청시 본인 권한 확인 로직 추가

### DIFF
--- a/src/main/java/com/sparta/gaeppa/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gaeppa/review/repository/ReviewRepository.java
@@ -16,4 +16,5 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     List<Review> getAllReviewsByStoreId(UUID storeId);
 
     Review findByOrder_OrderIdAndDeletedAtIsNull(UUID orderId);
+
 }

--- a/src/main/java/com/sparta/gaeppa/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gaeppa/review/service/ReviewService.java
@@ -98,10 +98,10 @@ public class ReviewService {
             }
         }
 
-        review.delete(userDetails.getUsername());
+        review.delete(userDetails.getMemberId());
 
         Store store = storeRepository.findById(review.getOrder().getStore().getStoreId())
                 .orElseThrow(() -> new ServiceException(ExceptionStatus.STORE_NOT_FOUND));
-        store.updateReviewAvg(review.getReviewScore());
+        store.rollbackReviewAvg(review.getReviewScore());
     }
 }

--- a/src/main/java/com/sparta/gaeppa/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gaeppa/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.sparta.gaeppa.review.service;
 
 import com.sparta.gaeppa.global.exception.ExceptionStatus;
 import com.sparta.gaeppa.global.exception.ServiceException;
+import com.sparta.gaeppa.members.entity.MemberRole;
 import com.sparta.gaeppa.order.entity.OrderStatus;
 import com.sparta.gaeppa.order.entity.Orders;
 import com.sparta.gaeppa.order.repository.OrderRepository;
@@ -85,12 +86,22 @@ public class ReviewService {
     }
 
     @Transactional
-    @PreAuthorize("hasAnyRole('ROLE_MASTER', 'ROLE_MANAGER')")
+    @PreAuthorize("hasAnyRole('ROLE_MASTER', 'ROLE_MANAGER', 'ROLE_CUSTOMER')")
     public void deleteReview(UUID reviewId, CustomUserDetails userDetails) {
 
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ServiceException(ExceptionStatus.REVIEW_NOT_FOUND));
 
+        if(userDetails.getMemberRole() == MemberRole.CUSTOMER) {
+            if(userDetails.getMemberId() != review.getOrder().getMember().getMemberId()) {
+                throw new ServiceException(ExceptionStatus.ACCESS_DENIED);
+            }
+        }
+
         review.delete(userDetails.getUsername());
+
+        Store store = storeRepository.findById(review.getOrder().getStore().getStoreId())
+                .orElseThrow(() -> new ServiceException(ExceptionStatus.STORE_NOT_FOUND));
+        store.updateReviewAvg(review.getReviewScore());
     }
 }

--- a/src/main/java/com/sparta/gaeppa/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gaeppa/review/service/ReviewService.java
@@ -93,7 +93,7 @@ public class ReviewService {
                 .orElseThrow(() -> new ServiceException(ExceptionStatus.REVIEW_NOT_FOUND));
 
         if(userDetails.getMemberRole() == MemberRole.CUSTOMER) {
-            if(userDetails.getMemberId() != review.getOrder().getMember().getMemberId()) {
+            if(userDetails.getMemberId().equals(review.getOrder().getMember().getMemberId())) {
                 throw new ServiceException(ExceptionStatus.ACCESS_DENIED);
             }
         }

--- a/src/main/java/com/sparta/gaeppa/store/entity/Store.java
+++ b/src/main/java/com/sparta/gaeppa/store/entity/Store.java
@@ -129,9 +129,16 @@ public class Store extends BaseEntity {
     public void rollbackReviewAvg(int canceledReviewScore) {
 
         this.reviewCount--;
-        this.reviewAvg = this.reviewAvg.multiply(BigDecimal.valueOf(reviewCount + 1))
+
+        if(this.reviewCount == 0) {
+            this.reviewAvg = BigDecimal.valueOf(0);
+        }
+
+        if(this.reviewCount > 0) {
+            this.reviewAvg = this.reviewAvg.multiply(BigDecimal.valueOf(reviewCount + 1))
                 .subtract(BigDecimal.valueOf(canceledReviewScore))
                 .divide(BigDecimal.valueOf(reviewCount), BigDecimal.ROUND_UNNECESSARY);
+        }
     }
 
 

--- a/src/main/java/com/sparta/gaeppa/store/entity/Store.java
+++ b/src/main/java/com/sparta/gaeppa/store/entity/Store.java
@@ -122,6 +122,17 @@ public class Store extends BaseEntity {
         this.reviewCount++;
         this.reviewAvg = this.reviewAvg.multiply(BigDecimal.valueOf(reviewCount - 1))
                 .add(BigDecimal.valueOf(newReviewScore))
-                .divide(BigDecimal.valueOf(reviewCount), 2, RoundingMode.HALF_UP); // 소수점 둘째 자리에서 반올림
+                .divide(BigDecimal.valueOf(reviewCount), BigDecimal.ROUND_UNNECESSARY);
     }
+
+    // Review 삭제시 업데이트시키는 메서드
+    public void rollbackReviewAvg(int canceledReviewScore) {
+
+        this.reviewCount--;
+        this.reviewAvg = this.reviewAvg.multiply(BigDecimal.valueOf(reviewCount + 1))
+                .subtract(BigDecimal.valueOf(canceledReviewScore))
+                .divide(BigDecimal.valueOf(reviewCount), BigDecimal.ROUND_UNNECESSARY);
+    }
+
+
 }


### PR DESCRIPTION
## 기능 설명

## 작업 내용
- 리뷰 평점 반올림 계산 방식 수정
- 리뷰 삭제 요청시 권한 확인 로직 추가
- 리뷰 삭제 시 잔여 리뷰수 0일 때 평점 계산 안되는 오류 수정

- 인가 후 주문,리뷰 테스트 완료
## 수정 사항

## 추가 작업 예정
